### PR TITLE
Feat/tour creation

### DIFF
--- a/Explorer/src/app/app.module.ts
+++ b/Explorer/src/app/app.module.ts
@@ -18,7 +18,7 @@ import { ProfileModule } from './feature-modules/stakeholders/profile.module';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
   ],
   imports: [
     BrowserModule,

--- a/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.css
+++ b/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.css
@@ -1,0 +1,38 @@
+.compact-table {
+    width: 50%; /* Manja širina */
+    margin: 10px auto; /* Centrirano na stranici */
+    border-collapse: collapse;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+th, td {
+    padding: 8px 10px; /* Manji padding */
+    text-align: left;
+    font-size: 0.9em; /* Smanjen font */
+}
+
+input, select {
+    width: 100%; /* Širina da ispuni ćeliju */
+    padding: 6px; /* Manji padding unutar polja */
+    font-size: 0.9em;
+    box-sizing: border-box;
+}
+
+button {
+    padding: 8px 16px;
+    font-size: 0.9em;
+    background-color: #3f51b5;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #2c387e;
+}
+
+.submit-row {
+    text-align: right; /* Dugme poravnato na desno */
+}

--- a/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.html
+++ b/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.html
@@ -1,0 +1,43 @@
+<form [formGroup]="tourForm">
+    <table>
+      <tr>
+        <td><label for="name">Name:</label></td>
+        <td>
+          <input type="text" id="name" name="name" placeholder="Name" formControlName="name" required>
+        </td>
+      </tr>
+      <tr>
+        <td><label for="description">Description:</label></td>
+        <td>
+          <input type="text" id="description" name="description" placeholder="Description" formControlName="description" required>
+        </td>
+      </tr>
+      <tr>
+        <td><label for="difficulty">Difficulty:</label></td>
+        <td>
+          <select id="difficulty" name="difficulty" formControlName="difficulty" required>
+            <option value="0">Easy</option>
+            <option value="1">Moderate</option>
+            <option value="2">Hard</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td><label for="tag">Tag:</label></td>
+        <td>
+          <select id="tag" name="tag" formControlName="tag" required>
+            <option value="0">Adventure</option>
+            <option value="1">Relaxation</option>
+            <option value="2">Historical</option>
+            <option value="3">Cultural</option>
+            <option value="4">Nature</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2" style="text-align: right;">
+          <button mat-raised-button type="submit" (click)="addTour()">Submit</button>
+        </td>
+      </tr>
+    </table>
+  </form>

--- a/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/addtour/addtour.component.ts
@@ -1,0 +1,46 @@
+import { Component, Output } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { TourAuthoringService } from '../tour-authoring.service';
+import { Tour } from '../model/tour.model';
+import { EventEmitter } from '@angular/core';
+
+
+
+@Component({
+  selector: 'xp-addtour',
+  templateUrl: './addtour.component.html',
+  styleUrls: ['./addtour.component.css']
+})
+export class AddtourComponent {
+
+  @Output() tourAdded = new EventEmitter<null>();
+
+  constructor(private service: TourAuthoringService) {}
+
+  tourForm  = new FormGroup({
+        name : new FormControl('', [Validators.required]),
+        description : new FormControl('', [Validators.required]),
+        status : new FormControl(0),
+        tag : new FormControl(0),
+        difficulty : new FormControl(0),
+        price : new FormControl(0, [Validators.required])
+  });
+
+  addTour(): void {
+    console.log(this.tourForm.value);
+
+    const tour : Tour = {
+      userId: 1,
+      equipment: [],
+      id: 0,
+      name: this.tourForm.value.name || "",
+      description: this.tourForm.value.description || "",
+      status: 0,
+      tag: Number(this.tourForm.value.tag) || 0,
+      difficulty: Number(this.tourForm.value.difficulty) || 0,
+      price: 0,
+    }
+    this.service.addTour(tour).subscribe({next: (_) => {this.tourAdded.emit();}});
+  }
+
+}

--- a/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.css
+++ b/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.css
@@ -1,45 +1,62 @@
-p {
-    font-size: 20px;
+.container {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin: 20px auto;
+    width: 80%;
+    gap: 20px;
+}
+
+.table-section {
+    width: 60%;
+    /* Add max-height and scrolling behavior */
+    max-height: 400px; 
+    overflow-y: auto; 
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.form-section {
+    width: 35%;
 }
 
 table {
     border-collapse: collapse;
     font-size: 0.9em;
     font-family: sans-serif;
-    min-width: 300px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
-    margin-left: 20px;
-    margin-top: 20px;
-}
-
-thead tr {
-    background-color: #3f51b5;
-    color: #ffffff;
-    text-align: left;
+    width: 100%;
 }
 
 th, td {
-    padding: 12px 15px;
+    padding: 12px;
+    text-align: center;
+    border-bottom: 1px solid #ddd;
 }
 
-tbody tr {
-    border-bottom: 1px solid #dddddd;
+/* Keep header sticky while scrolling */
+thead tr {
+    background-color: #3f51b5;
+    color: white;
+    position: sticky;
+    top: 0; /* Fixed header on scroll */
+    z-index: 1;
 }
 
-tbody tr:last-of-type {
-    border-bottom: 2px solid #3f51b5;
-}
-
-tbody tr.active-row {
-    font-weight: bold;
-    color: #3f51b5;
-}
-
-.clickable-row {
-    cursor: pointer;
-    transition: background-color 0.1s;
-  }
-  
 .clickable-row:hover {
-background-color: #b0d4f2; /* Light gray background on hover */
+    background-color: #b0d4f2;
+}
+
+button {
+    margin-top: 10px;
+    padding: 8px 12px;
+    font-size: 0.9em;
+    background-color: #3f51b5;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+button:hover {
+    background-color: #2c387e;
 }

--- a/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.html
+++ b/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.html
@@ -1,15 +1,33 @@
-<div>
-    <br>
-    <table>
-        <th>
-            <tr>My Tours</tr>
-        </th>
+<div class="container">
+    <div class="table-section">
+      <div class="table-title">
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Difficulty</th>
+            <th>Status</th>
+            <th>Tag</th>
+            <th>Price</th>
+          </tr>
+        </thead>
         <tbody>
-            <tr *ngFor="let tour of tours" (click)="showTourClick(tour)" class="clickable-row">
-                <td>{{tour.name}}</td>
-                <td>{{tour.description}}</td>
-                <td>{{tour.price}}</td>
-            </tr>
+          <tr *ngFor="let tour of tours" (click)="showTourClick(tour)" class="clickable-row">
+            <td>{{ tour.name }}</td>
+            <td>{{ tour.description }}</td>
+            <td>{{ getDifficultyLabel(tour.difficulty) }}</td>
+            <td>{{ getStatusLabel(tour.status) }}</td>
+            <td>{{ getTagLabel(tour.tag) }}</td>
+            <td>{{ tour.price }}</td>
+          </tr>
         </tbody>
-    </table>
-</div>
+      </table>
+    </div>
+  
+    <div class="form-section">
+      <xp-addtour (tourAdded) = "getTours()" ></xp-addtour>
+    </div>
+  </div>
+  

--- a/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/mytours/mytours.component.ts
@@ -4,11 +4,37 @@ import { PagedResult } from '../shared/model/tour.module';
 import { Tour } from '../model/tour.model';
 import { Router } from '@angular/router';
 
+
+export enum Status
+{
+   Draft = 0,
+   Published = 1,
+   Archived = 2
+}
+
+export enum Tag 
+{
+   Adventure = 0,
+   Relaxation = 1,
+   Historical = 2,
+   Cultural = 3,
+   Nature = 4
+}
+
+export enum Difficulty  
+{
+   Easy = 0,
+   Moderate = 1,
+   Hard = 2
+}
+
 @Component({
   selector: 'xp-mytours',
   templateUrl: './mytours.component.html',
   styleUrls: ['./mytours.component.css']
 })
+
+
 export class MyToursComponent implements OnInit{
 
   tours: Tour[] = []
@@ -34,4 +60,17 @@ export class MyToursComponent implements OnInit{
     showTourClick(tour: Tour): void {
       this.router.navigate(['/edittours'], { queryParams: { tour: JSON.stringify(tour) } });
     }
+
+    getStatusLabel(status: number): string {
+      return Status[status];
+    }
+  
+    getTagLabel(tag: number): string {
+      return Tag[tag];
+    }
+  
+    getDifficultyLabel(difficulty: number): string {
+      return Difficulty[difficulty];
+    }
+
 }

--- a/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.module.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.module.ts
@@ -3,17 +3,18 @@ import { CommonModule } from '@angular/common';
 import { MyToursComponent } from './mytours/mytours.component';
 import { MaterialModule } from "src/app/infrastructure/material/material.module";
 import { EditTourComponent } from './edittour/edittour.component';
-
-
-
+import { AddtourComponent } from './addtour/addtour.component';
+import { ReactiveFormsModule } from '@angular/forms';
 @NgModule({
   declarations: [
     MyToursComponent,
-    EditTourComponent
+    EditTourComponent,
+    AddtourComponent
   ],
   imports: [
     CommonModule,
-    MaterialModule
+    MaterialModule,
+    ReactiveFormsModule
   ]
 })
 export class TourAuthoringModule { }

--- a/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.service.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.service.ts
@@ -25,4 +25,8 @@ export class TourAuthoringService {
     return this.http.put('https://localhost:44333/api/author/tour/equipment', result)
   }
   
+  addTour(tour : Tour): Observable<Tour>{
+    return this.http.post<Tour>('https://localhost:44333/api/author/tour', tour)
+  }
+
 }


### PR DESCRIPTION
## **Change goal**
As an author,
I want to create tours by specifying the tours name, description, difficulty, and tags,
So that I can organize and manage my tours more effectively from draft status before publishing.
Acceptance Criteria:
1.When creating a tour, the status should automatically be set to draft.
2.The initial price of the tour should be set to 0 by default.
3.The tour should include the following fields:
4.Name (required)
5.Description (required)
6.Difficulty ( easy,intermediate , hard)
7.Tags ( Adventure,Relaxation,Historical,Cultural,Nature)
8.The author should be able to view a list of all tours they have created, including both draft,published and archived tours.
## **![projekat_A](https://github.com/user-attachments/assets/065b29c8-d0ab-42ec-b4ab-09f9ce3d9e32)**