### PR TITLE
feat: added getAll, create and update functionality

### DIFF
--- a/Explorer/src/app/app.module.ts
+++ b/Explorer/src/app/app.module.ts
@@ -1,20 +1,21 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { AppRoutingModule } from './infrastructure/routing/app-routing.module';
-import { AppComponent } from './app.component';
-import { LayoutModule } from './feature-modules/layout/layout.module';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MaterialModule } from './infrastructure/material/material.module';
+import { AppComponent } from './app.component';
 import { AdministrationModule } from './feature-modules/administration/administration.module';
 import { BlogModule } from './feature-modules/blog/blog.module';
+import { LayoutModule } from './feature-modules/layout/layout.module';
 import { MarketplaceModule } from './feature-modules/marketplace/marketplace.module';
+import { ProfileModule } from './feature-modules/stakeholders/profile.module';
 import { TourAuthoringModule } from './feature-modules/tour-authoring/tour-authoring.module';
 import { TourExecutionModule } from './feature-modules/tour-execution/tour-execution.module';
 import { AuthModule } from './infrastructure/auth/auth.module';
-import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { JwtInterceptor } from './infrastructure/auth/jwt/jwt.interceptor';
-import { ProfileModule } from './feature-modules/stakeholders/profile.module';
+import { MaterialModule } from './infrastructure/material/material.module';
+import { AppRoutingModule } from './infrastructure/routing/app-routing.module';
 
 @NgModule({
   declarations: [
@@ -33,7 +34,8 @@ import { ProfileModule } from './feature-modules/stakeholders/profile.module';
     TourAuthoringModule,
     TourExecutionModule,
     AuthModule,
-    HttpClientModule
+    HttpClientModule,
+    ReactiveFormsModule
   ],
   providers: [
     {

--- a/Explorer/src/app/feature-modules/layout/navbar/navbar.component.html
+++ b/Explorer/src/app/feature-modules/layout/navbar/navbar.component.html
@@ -6,6 +6,7 @@
             <button *ngIf="user && user.username !== ''" color="accent" mat-raised-button (click)="onLogout()">Logout</button>
             <button *ngIf="user && user.username !== ''" color="primary" mat-raised-button (click)="showProfile()">Profile</button>
             <button *ngIf="user && user.username !== '' && user.role ==='author'" color="primary" mat-raised-button (click)="showMyTours()">My Tours</button>
+            <button *ngIf="user && user.username !== '' && user.role ==='tourist'" color="primary" mat-raised-button (click)="showClub()">Club</button>
             <button color="primary" mat-raised-button [routerLink]="['home']">Home</button>
             <button *ngIf="user && user.role === 'administrator'"color="primary" mat-raised-button [routerLink]="['equipment']">Manage equipment</button>
         </div>

--- a/Explorer/src/app/feature-modules/layout/navbar/navbar.component.ts
+++ b/Explorer/src/app/feature-modules/layout/navbar/navbar.component.ts
@@ -31,4 +31,8 @@ export class NavbarComponent implements OnInit {
   showMyTours(): void{
     this.router.navigate(['/mytours'])
   }
+
+  showClub(): void{
+    this.router.navigate(['/club'])
+  }
 }

--- a/Explorer/src/app/feature-modules/tour-authoring/club.service.spec.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/club.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ClubService } from './club.service';
+
+describe('ClubService', () => {
+  let service: ClubService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ClubService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Explorer/src/app/feature-modules/tour-authoring/club.service.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/club.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Club } from '../tour-authoring/model/club.model';
+import { PagedResult } from './shared/model/tour.module';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClubService {
+
+  constructor(private http: HttpClient) { }
+
+  getAllClubs(): Observable<PagedResult<Club>>{
+    return this.http.get<PagedResult<Club>>('https://localhost:44333/api/tourist/club/')
+  }
+
+  addClub(result: Club): Observable<any> {
+    return this.http.post('https://localhost:44333/api/tourist/club/', result);
+  }
+
+  updateClub(result: Club): Observable<any> {
+    return this.http.put(`https://localhost:44333/api/tourist/club/${result.id}`, result);
+  }
+  
+  
+}

--- a/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.css
+++ b/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.css
@@ -1,0 +1,24 @@
+table {
+    width: 80%;
+    border-collapse: collapse;
+    text-align: center;
+  }
+  
+  th, td {
+    padding: 12px;
+    border: 1px solid #ddd;
+    text-align: left;
+  }
+  
+  tr:hover {
+    background-color: #f5f5f5;
+  }
+  
+  .clickable-row {
+    cursor: pointer;
+  }
+  
+  .clickable-row:hover {
+    background-color: #d3d3d3;
+  }
+  

--- a/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.html
+++ b/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.html
@@ -1,0 +1,85 @@
+<div>
+    <h1>Clubs</h1>
+    <br>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let club of clubs" (click)="showClubClick(club)" class="clickable-row">
+          <td>{{ club.name }}</td>
+          <td>{{ club.description }}</td>
+          <td>
+            <button mat-icon-button (click)="editClub(club)">
+              <mat-icon>edit</mat-icon>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  
+    <div *ngIf="clubs.length === 0">
+      <p>No clubs available.</p>
+    </div>
+  </div>
+
+<form [formGroup]="clubForm" *ngIf="!shouldEdit">
+    <h2>Create Club</h2>
+    <div>
+        <mat-form-field>
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" type="text" placeholder="Enter club name" />
+        </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>Description</mat-label>
+            <textarea matInput
+                cdkTextareaAutosize
+                cdkAutosizeMinRows="1"
+                formControlName="description"
+                cdkAutosizeMaxRows="5"
+                placeholder="Enter club description"></textarea>
+        </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>ImageId</mat-label>
+            <input matInput formControlName="imageId" type="text" placeholder="Enter Image Id" />
+        </mat-form-field>
+
+        <button color="primary" type="submit" (click)="addClub()" mat-raised-button>Done</button>
+    </div>
+</form>
+
+<form [formGroup]="clubForm" *ngIf="shouldEdit">
+    <h2>Update Club</h2>
+    <div>
+        <mat-form-field>
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" type="text" placeholder="Enter club name" />
+        </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>Description</mat-label>
+            <textarea matInput
+                cdkTextareaAutosize
+                cdkAutosizeMinRows="1"
+                formControlName="description"
+                cdkAutosizeMaxRows="5"
+                placeholder="Enter club description"></textarea>
+        </mat-form-field>
+
+        <mat-form-field>
+            <mat-label>ImageId</mat-label>
+            <input matInput formControlName="imageId" type="number" placeholder="Enter Image Id" />
+        </mat-form-field>
+
+        <button color="primary" type="submit" (click)="updateClub()" mat-raised-button>Update</button>
+    </div>
+</form>
+
+
+  

--- a/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/club/club/club.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ClubService } from '../../club.service';
+import { Club } from '../../model/club.model';
+import { PagedResult } from '../../shared/model/tour.module';
+
+@Component({
+  selector: 'xp-club',
+  templateUrl: './club.component.html',
+  styleUrls: ['./club.component.css']
+})
+export class ClubComponent implements OnInit {
+
+  clubs: Club[] = [];
+  clubForm: FormGroup;
+  shouldEdit: boolean = false;
+  editingClubId: number | null = null;
+
+  constructor(private fb: FormBuilder, private service: ClubService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.clubForm = this.fb.group({
+      name: ['', Validators.required],
+      description: [''],
+      imageId: [null, [Validators.required, Validators.pattern("^[0-9]*$")]],
+    });
+    this.getClubs();
+  }
+
+getClubs(): void {
+  this.service.getAllClubs().subscribe({
+    next: (result: PagedResult<Club>) => {
+      this.clubs = result.results;
+    },
+    error: (err: any) => {
+      console.log(err);
+    }
+  });
+}
+
+addClub(): void {
+  if (this.clubForm.valid) {
+    const clubData = {
+      ...this.clubForm.value,
+      ownerId: 1
+    };
+
+    this.service.addClub(clubData).subscribe({
+      next: (response) => {
+        console.log('Club added successfully!');
+      },
+      error: (err) => {
+        console.log('Error adding club:', err);
+      }
+    });
+  }
+}
+
+
+updateClub(): void {
+  if (this.clubForm.valid && this.editingClubId !== null) {
+    const clubData = {
+      ...this.clubForm.value,
+      id: this.editingClubId,
+      ownerId: 1
+    };
+
+    this.service.updateClub(clubData).subscribe({
+      next: (response) => {
+        console.log('Club updated successfully!');
+        this.getClubs();
+        this.clubForm.reset();
+        this.shouldEdit = false; 
+      },
+      error: (err) => {
+        console.log('Error updating club:', err);
+      }
+    });
+  }
+}
+
+  showClubClick(club: Club): void {
+    this.shouldEdit = true;
+    this.clubForm.patchValue({
+      name: club.name,
+      description: club.description
+    });
+  }
+
+  editClub(club: Club): void {
+    this.shouldEdit = true;
+    this.editingClubId = club.id;
+  
+    this.clubForm.patchValue({
+      name: club.name,
+      description: club.description,
+      imageId: club.imageId
+    });
+  }
+}
+
+

--- a/Explorer/src/app/feature-modules/tour-authoring/model/club.model.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/model/club.model.ts
@@ -1,0 +1,7 @@
+export interface Club {
+    id: number;
+    name: string;
+    description: string;
+    imageId: number;
+    ownerId: number;
+}

--- a/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.module.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.module.ts
@@ -1,19 +1,23 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MyToursComponent } from './mytours/mytours.component';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from "src/app/infrastructure/material/material.module";
+import { ClubComponent } from './club/club/club.component';
 import { EditTourComponent } from './edittour/edittour.component';
+import { MyToursComponent } from './mytours/mytours.component';
 
 
 
 @NgModule({
   declarations: [
     MyToursComponent,
-    EditTourComponent
+    EditTourComponent,
+    ClubComponent
   ],
   imports: [
     CommonModule,
-    MaterialModule
+    MaterialModule,
+    ReactiveFormsModule
   ]
 })
 export class TourAuthoringModule { }

--- a/Explorer/src/app/infrastructure/routing/app-routing.module.ts
+++ b/Explorer/src/app/infrastructure/routing/app-routing.module.ts
@@ -1,13 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { HomeComponent } from 'src/app/feature-modules/layout/home/home.component';
-import { LoginComponent } from '../auth/login/login.component';
 import { EquipmentComponent } from 'src/app/feature-modules/administration/equipment/equipment.component';
-import { AuthGuard } from '../auth/auth.guard';
-import { RegistrationComponent } from '../auth/registration/registration.component';
+import { HomeComponent } from 'src/app/feature-modules/layout/home/home.component';
 import { ProfileComponent } from 'src/app/feature-modules/stakeholders/profile/profile.component';
-import { MyToursComponent } from 'src/app/feature-modules/tour-authoring/mytours/mytours.component';
+import { ClubComponent } from 'src/app/feature-modules/tour-authoring/club/club/club.component';
 import { EditTourComponent } from 'src/app/feature-modules/tour-authoring/edittour/edittour.component';
+import { MyToursComponent } from 'src/app/feature-modules/tour-authoring/mytours/mytours.component';
+import { AuthGuard } from '../auth/auth.guard';
+import { LoginComponent } from '../auth/login/login.component';
+import { RegistrationComponent } from '../auth/registration/registration.component';
 
 const routes: Routes = [
   {path: 'home', component: HomeComponent},
@@ -15,6 +16,7 @@ const routes: Routes = [
   {path: 'register', component: RegistrationComponent},
   {path: 'equipment', component: EquipmentComponent, canActivate: [AuthGuard],},
   {path: 'profile', component: ProfileComponent, canActivate: [AuthGuard],},
+  {path: 'club', component: ClubComponent, canActivate: [AuthGuard],},
   {path: 'mytours', component: MyToursComponent, canActivate: [AuthGuard],},
   {path: 'edittours', component: EditTourComponent, canActivate: [AuthGuard]}
 ];


### PR DESCRIPTION
As a Tourist,
I want to create, update, or modify a club that contains a name, description, and picture,
So that other tourists can view my club and engage with it.

The club entity must include the following fields:
Name (required)
Description (optional)
Picture (optional)
The user interface should allow tourists to:
Add, update, or delete the club's name, description, and picture.
Other tourists should be able to view all clubs created by other tourists.
Only the tourist who created the club is considered its owner and has permission to edit or delete the club.
![fe-explorer](https://github.com/user-attachments/assets/64266c21-e073-4680-a477-1ed718ac809d)

