### PR TITLE
feat:administrator blocking user done

### DIFF
--- a/Explorer/src/app/feature-modules/administration/account-management/account-management.component.html
+++ b/Explorer/src/app/feature-modules/administration/account-management/account-management.component.html
@@ -2,6 +2,7 @@
   <table>
     <thead>
       <tr>
+        <th>Id</th>
         <th>Username</th>
         <th>Email</th>
         <th>Role</th>
@@ -11,10 +12,18 @@
     <tbody>
       <ng-container *ngFor="let acc of account">
         <tr *ngIf="acc.username !== user?.username">
+          <td>{{acc.userId}}</td>
           <td>{{acc.username}}</td>
           <td>{{acc.email}}</td>
           <td>{{ getRoleName(acc.role) }}</td>
-          <td><button>Block</button></td>
+          <td>
+            <ng-container *ngIf="acc.isBlocked; else notBlocked">
+              Blocked
+            </ng-container>
+            <ng-template #notBlocked>
+              <button (click)="blockUser(acc)">Block</button>
+            </ng-template>
+          </td>
         </tr>
       </ng-container>
     </tbody>

--- a/Explorer/src/app/feature-modules/administration/account-management/account-management.component.ts
+++ b/Explorer/src/app/feature-modules/administration/account-management/account-management.component.ts
@@ -16,14 +16,7 @@ export class AccountManagementComponent implements OnInit {
   constructor(private service: AdministrationService, private authService: AuthService){ }
   
   ngOnInit(): void {
-    this.service.getAccount().subscribe({
-      next: (result: PagedResult<Account>) => {
-        this.account = result.results
-      },
-      error(err: any) {
-        console.log(err)
-      }
-    })
+    this.getAccounts();
     this.authService.user$.subscribe(user => {
       this.user = user;
     });
@@ -40,5 +33,37 @@ export class AccountManagementComponent implements OnInit {
       default:
         return 'Unknown';
     }
+  }
+
+  blockUser(account: Account): void {
+
+    const userToBlock = this.account.find(acc => acc.userId === account.userId);
+    if (userToBlock) {
+      userToBlock.isBlocked = true;
+
+      // Pozovi servis za ažuriranje korisničkog naloga (pretpostavljam da imaš metodu za to)
+      this.service.blockAccount(userToBlock).subscribe({
+        next: () => {
+          console.log(`User ${userToBlock.username} has been blocked.`);
+          this.getAccounts(); 
+        },
+        error: (err: any) => {
+          console.error('Error during blocking the user:', err);
+        }
+      });
+    } else {
+      console.log('User not found.');
+    }
+  }
+
+  getAccounts(): void{
+    this.service.getAccount().subscribe({
+      next: (result: PagedResult<Account>) => {
+        this.account = result.results;
+      },
+      error: (err: any) => {
+        console.log(err);
+      }
+    });
   }
 }

--- a/Explorer/src/app/feature-modules/administration/administration.service.ts
+++ b/Explorer/src/app/feature-modules/administration/administration.service.ts
@@ -33,4 +33,8 @@ export class AdministrationService {
     return this.http.get<PagedResults<Account>>('https://localhost:44333/api/administrator/account');
   }
 
+  blockAccount(account: Account): Observable<Account>{
+    return this.http.put<Account>('https://localhost:44333/api/administrator/account/block/', account);
+  }
+
 }

--- a/Explorer/src/app/feature-modules/administration/model/account.model.ts
+++ b/Explorer/src/app/feature-modules/administration/model/account.model.ts
@@ -1,4 +1,5 @@
 export interface Account{
+  userId: number,
   username: string,
   email: string,
   role: number,


### PR DESCRIPTION
## Change goal
As an administrator,
I want to review and block user accounts,
So that I can ensure the platform remains safe and functional for all users

Acceptance criteria:
 - The administrator can see the following details when reviewing user accounts: username, email, and role (guide, tourist, administrator).
 - The administrator cannot see the user's password
 - The administrator has the option to block a user account
 - Blocked users are unable to log in to the system
 
 ## UI changes
![SS1](https://github.com/user-attachments/assets/b160f0ac-cd62-4c8b-acfb-ac783c47dd26)
