### PR TITLE
Feat/tour execution session

### DIFF
--- a/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.css
+++ b/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.css
@@ -7,7 +7,6 @@
 }
 
 .map_and_button_container{
-    border: 1px solid black;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.css
+++ b/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.css
@@ -1,3 +1,23 @@
+.initial_container{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #f5f5f5;
+    flex-direction: column;
+}
+
+.map_and_button_container{
+    border: 1px solid black;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+}
+.action_button{
+    margin: 50px;
+}
+
+
 .position-selection-container {
     text-align: center; /* Center-align the text */
     margin-bottom: 20px; /* Add some space below */
@@ -14,6 +34,7 @@
 }
 
 .map-container {
+    width: 1000px;
     border-radius: 10px; /* Round the corners */
     overflow: hidden; /* Ensure no overflow outside the border */
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); /* Add a subtle shadow */
@@ -23,3 +44,35 @@ xp-map {
     width: 100%; /* Make the map take the full width */
     height: 400px; /* Set a fixed height for the map */
 }
+
+
+.btn {
+    flex: 1;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 4px;
+    font-weight: 500;
+    cursor: pointer;
+    flex-direction: column;
+    gap: 0.5rem;
+    transition: all 0.2s ease;
+    margin-left: 30px;
+  
+    &.btn-primary {
+      background-color: var(--primary-brown);
+      color: var(--white);
+  
+      &:hover {
+        background-color: var(--dark-brown);
+      }
+    }
+  
+    &.btn-accent {
+      background-color: var(--light-brown);
+      color: var(--dark-brown);
+  
+      &:hover {
+        background-color: var(--lighter-brown);
+      }
+    }
+  }

--- a/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.html
+++ b/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.html
@@ -1,13 +1,19 @@
-<div class="position-selection-container">
-    <h2>Select Your Position</h2>
-    <p class="instructions">Click on the map to choose your location.</p>
-</div>
-
-<div class="map-container">
-    <xp-map 
-        (locationSelected)="onLocationSelected($event)" 
-        [touristPosition]="touristPosition"
-        [clearMarkersTrigger]="clearMarkersFlag" 
-        (markersCleared)="onMarkersCleared()">
-    </xp-map>
+<div class = "initial_container">
+    <div class="position-selection-container">
+        <h2>Select Your Position</h2>
+        <p class="instructions">Click on the map to choose your location.</p>
+    </div>
+    <div class = "map_and_button_container">
+        <div class="map-container">
+            <xp-map 
+                (locationSelected)="onLocationSelected($event)" 
+                [touristPosition]="touristPosition"
+                [clearMarkersTrigger]="clearMarkersFlag" 
+                (markersCleared)="onMarkersCleared()"
+                [checkpointCordinatesCollection]="checkpointCordinates">
+            </xp-map>
+        </div>
+        <button (click)="endTour()" class="btn btn-accent">
+            {{ executedCheckpoints.length === 0 ? 'Finish Tour' : 'Abandon Tour' }}
+        </button>    </div>
 </div>

--- a/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.ts
+++ b/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.ts
@@ -5,9 +5,8 @@ import { ProfileService } from '../profile.service';
 import { Person } from '../model/person';
 import { User } from 'src/app/infrastructure/auth/model/user.model';
 import { AuthService } from 'src/app/infrastructure/auth/auth.service';
-
-
-
+import { TourExecutionService } from 'src/app/feature-modules/tour-execution/tour-execution.service';
+import { TourExecution } from '../../tour-execution/model/tourExecution-model';
 @Component({
   selector: 'xp-position-simulator',
   templateUrl: './position-simulator.component.html',
@@ -15,30 +14,101 @@ import { AuthService } from 'src/app/infrastructure/auth/auth.service';
 })
 export class PositionSimulatorComponent {
   touristPosition: TouristPosition | null = null;
+  person: Person | null = null;
+  tourExecution: TourExecution; 
+  executedCheckpoints : any[] = [];
+  checkpointCordinates: any[] = [];
   user: User | undefined;
   clearMarkersFlag: boolean = false;
   currentTouristPosition: TouristPosition | null = null;
-  constructor(private service: ProfileService, private authService: AuthService) {}
+  intervalId: any;
+  constructor(private service: ProfileService, private authService: AuthService, private execService: TourExecutionService) {}
 
   ngOnInit(): void {
     this.authService.user$.subscribe(user => {
       this.user = user;
       if (this.user?.id) {
-        // Retrieve the current position for the user on initialization
         this.service.getTouristPosition(this.user.id).subscribe({
-          next: (position: TouristPosition) => {
-            this.touristPosition = position;
-            console.log('Retrieved Tourist Position:', this.touristPosition);
+          next: (per: Person) => {
+            this.person = per;
+            this.touristPosition = per.touristPosition;
+            localStorage.setItem('touristPosition', JSON.stringify(this.touristPosition));
+           // console.log('Retrieved Tourist Position:', this.touristPosition);
+           // console.log('Retrieved Person:', this.person);
+            this.startPositionCheckInterval(); 
           },
           error: (error) => {
             console.error('Error retrieving tourist position:', error);
           }
         });
+        this.execService.loadTourExecution(this.user.id).subscribe({next: (execution: TourExecution) => {
+          this.tourExecution = execution;
+          //console.log("Tour Execution:", this.tourExecution);
+          this.updateCheckpoints();
+        }});
       } else {
         console.error('User ID is not defined.');
       }
     });
   }
+
+  updateCheckpoints(): void {
+    console.log("Da li udjes posle brisanaj checkpointa")
+    const checkpointIds = this.tourExecution.tourExecutionCheckpoints
+          .filter(checkpoint => checkpoint.arrivalAt === null)
+          .map(checkpoint => checkpoint.checkpointId);
+        
+        //console.log("Checkpoint IDs with null ArrivalAt:", checkpointIds);
+          this.execService.getTourCheckpoints(checkpointIds).subscribe({
+            next: (checkpoints: any) => {
+              this.executedCheckpoints = checkpoints.results;
+              console.log("Checkpoints:", this.executedCheckpoints);
+             this.checkpointCordinates =  this.getCheckpointCoordinates();
+             console.log("Checkpoints coordinates:", this.checkpointCordinates);
+            },
+            error: (error) => {
+              console.error('Error fetching checkpoints:', error);
+          }});
+  }
+
+
+
+
+  getCheckpointCoordinates(): { latitude: number, longitude: number }[] {
+
+
+    if (!this.touristPosition || !this.tourExecution) {
+      return [];
+    }
+    //console.log("Tourist position:", this.touristPosition);
+    return [
+      { latitude: this.touristPosition.latitude, longitude: this.touristPosition.longitude },
+      ...this.executedCheckpoints
+        .map(checkpoint => ({
+          latitude: checkpoint.latitude,
+          longitude: checkpoint.longitude
+        }))
+    ];
+  }
+
+
+
+  startPositionCheckInterval(): void {
+    this.intervalId = setInterval(() => {
+      const storedPosition = JSON.parse(localStorage.getItem('touristPosition') || '{}');
+      console.log("Vreme tajmer")
+      //console.log('Proveravam trenutnu lokaciju:', storedPosition)
+      //console.log('Trenutna lokacija:', storedPosition)
+      //console.log('Lokacija turiste:', this.touristPosition)
+      if (storedPosition.latitude !== this.touristPosition?.latitude || storedPosition.longitude !== this.touristPosition?.longitude) {
+        this.updateTouristPosition();
+      }
+    }, 10000); 
+  }
+
+
+
+
 
   clearMarkers(){
     this.clearMarkersFlag = true;
@@ -50,25 +120,57 @@ export class PositionSimulatorComponent {
     });
   }
 
-  onLocationSelected(event: {lat: number, lng: number}): void {
+  onLocationSelected(event: { lat: number; lng: number }): void {
     const { lat, lng } = event;
-    this.touristPosition = { latitude: lat, longitude: lng };
-    console.log('New Tourist Position:', this.touristPosition);
+    this.touristPosition = { latitude: lat, longitude: lng };    
+    console.log('Tourist position updated locally:', this.touristPosition);
+  }
 
-    // Call the updateTouristPosition method to update the person's location
+  updateTouristPosition(): void {
     if (this.user?.id && this.touristPosition) {
       this.service.updateTouristPosition(this.user.id, this.touristPosition).subscribe({
         next: (updatedPerson: Person) => {
-          console.log('Updated Person Position:', updatedPerson);
+          this.touristPosition = updatedPerson.touristPosition;
+          console.log('A sto ne udjes ovde ako si updated:', this.touristPosition);
+
+          localStorage.setItem('touristPosition', JSON.stringify(this.touristPosition));
         },
         error: (error) => {
           console.error('Error updating tourist position:', error);
         }
       });
-    } else {
-      console.error('User ID or tourist position is not defined.');
+      console.log('Checking tourist position:', this.touristPosition);
+      this.execService.checkTouristPosition(this.touristPosition).subscribe({
+        next: (currentExe: TourExecution) => {
+          console.log('Current exe after saving:', currentExe);
+          this.tourExecution = currentExe;
+          this.updateCheckpoints();
+        },
+        error: (error) => {
+          console.error('Error checking tourist position:', error);
+        }
+
+      });
     }
-    
+  }
+
+  endTour(): void {
+    this.execService.endTour(this.tourExecution).subscribe({
+      next: (execution: TourExecution) => {
+        console.log('Tour ended:', execution);
+        this.tourExecution = execution;
+        this.updateCheckpoints();
+      },
+      error: (error) => {
+        console.error('Error ending tour:', error);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
   }
 }
 

--- a/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.ts
+++ b/Explorer/src/app/feature-modules/stakeholders/position-simulator/position-simulator.component.ts
@@ -7,6 +7,7 @@ import { User } from 'src/app/infrastructure/auth/model/user.model';
 import { AuthService } from 'src/app/infrastructure/auth/auth.service';
 import { TourExecutionService } from 'src/app/feature-modules/tour-execution/tour-execution.service';
 import { TourExecution } from '../../tour-execution/model/tourExecution-model';
+import { Router } from '@angular/router';
 @Component({
   selector: 'xp-position-simulator',
   templateUrl: './position-simulator.component.html',
@@ -22,7 +23,7 @@ export class PositionSimulatorComponent {
   clearMarkersFlag: boolean = false;
   currentTouristPosition: TouristPosition | null = null;
   intervalId: any;
-  constructor(private service: ProfileService, private authService: AuthService, private execService: TourExecutionService) {}
+  constructor(private service: ProfileService, private authService: AuthService, private execService: TourExecutionService, private router: Router) {}
 
   ngOnInit(): void {
     this.authService.user$.subscribe(user => {
@@ -160,6 +161,7 @@ export class PositionSimulatorComponent {
         console.log('Tour ended:', execution);
         this.tourExecution = execution;
         this.updateCheckpoints();
+        this.router.navigate(['/']); // Navigate on success
       },
       error: (error) => {
         console.error('Error ending tour:', error);

--- a/Explorer/src/app/feature-modules/stakeholders/profile.service.ts
+++ b/Explorer/src/app/feature-modules/stakeholders/profile.service.ts
@@ -29,7 +29,7 @@ export class ProfileService {
     updateTouristPosition(userId: number, positionDto: TouristPosition): Observable<Person> {
       return this.http.put<Person>(environment.apiHost + `person/${userId}/position`, positionDto);
     }
-    getTouristPosition(userId: number): Observable<TouristPosition>{
-      return this.http.get<TouristPosition>(environment.apiHost + `person/${userId}`);
+    getTouristPosition(userId: number): Observable<Person>{
+      return this.http.get<Person>(environment.apiHost + `person/${userId}`);
     }  
 }

--- a/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.service.ts
+++ b/Explorer/src/app/feature-modules/tour-authoring/tour-authoring.service.ts
@@ -67,6 +67,7 @@ export class TourAuthoringService {
   }
 
   getTourCheckpoints(checkpointIds: number[]): Observable<PagedResult<Checkpoint>> {
+    console.log("Testic:" ,checkpointIds);
     return this.http.post<PagedResult<Checkpoint>>('https://localhost:44333/api/author/checkpoint/checkpoints/getSome', checkpointIds);
   }
 }

--- a/Explorer/src/app/feature-modules/tour-execution/model/tourExecution-model.ts
+++ b/Explorer/src/app/feature-modules/tour-execution/model/tourExecution-model.ts
@@ -7,4 +7,5 @@ export interface TourExecution {
     status: number;
     sessionEndingTime: Date;
     lastActivity: Date;
+    tourExecutionCheckpoints: any[];
   }

--- a/Explorer/src/app/feature-modules/tour-execution/tour-execution.service.ts
+++ b/Explorer/src/app/feature-modules/tour-execution/tour-execution.service.ts
@@ -7,6 +7,8 @@ import { Tour } from '../tour-authoring/model/tour.model';
 import { TourReview } from './model/tour-review.model';
 import { environment } from 'src/env/environment';
 import { TourExecution } from './model/tourExecution-model';
+import { TouristPosition } from '../stakeholders/model/tourist-position';
+import { Checkpoint } from '../tour-authoring/model/checkpoint.model';
 @Injectable({
   providedIn: 'root'
 })
@@ -49,6 +51,19 @@ export class TourExecutionService {
 
   updateReview(review: TourReview): Observable<TourReview>{
     return this.http.put<TourReview>('https://localhost:44333/api/tour/reviews/update/review', review);
+  }
+  checkTouristPosition(tourist : TouristPosition): Observable<TourExecution>{
+    return this.http.post<TourExecution>('https://localhost:44333/api/tour/execution/checkTouristPosition', tourist);
+  }
+  loadTourExecution(tourId: number): Observable<TourExecution>{
+    return this.http.get<TourExecution>(`https://localhost:44333/api/tour/execution/load`);
+  }
+
+  getTourCheckpoints(checkpointIds: number[]): Observable<PagedResult<Checkpoint>> {
+    return this.http.post<PagedResult<Checkpoint>>('https://localhost:44333/api/tour/execution/checkpoints/getSome', checkpointIds);
+  }
+  endTour(tour: TourExecution): Observable<TourExecution>{
+    return this.http.post<TourExecution>('https://localhost:44333/api/tour/execution/end',tour);
   }
 
 }

--- a/Explorer/src/app/shared/map/map.component.ts
+++ b/Explorer/src/app/shared/map/map.component.ts
@@ -18,6 +18,7 @@ export class MapComponent implements AfterViewInit,OnDestroy {
   @Input() objectCollection: Object[] | null = null;
   //@Input() checkpointCollection: any[] | null = null;
   @Input() checkpointObjectCollection: any[] | null = null;
+  @Input() checkpointCordinatesCollection: any[] | null = null;
   @Input() checkpointCollection: Checkpoint[] | null = null;
   @Input() editing: boolean = false;
   @Output() markersCleared: EventEmitter<void> = new EventEmitter<void>();
@@ -175,8 +176,7 @@ export class MapComponent implements AfterViewInit,OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if(this.markers.length == 0){
       if (changes['touristPosition'] && changes['touristPosition'].currentValue) {
-        console.log(changes['touristPosition'].currentValue.position);
-        this.addTouristMarker(changes['touristPosition'].currentValue.position);
+        this.addTouristMarker(changes['touristPosition'].currentValue);
       }
     }
     if (changes['objectCollection'] && changes['objectCollection'].currentValue) {
@@ -191,12 +191,26 @@ export class MapComponent implements AfterViewInit,OnDestroy {
     if (changes['checkpointObjectCollection'] && changes['checkpointObjectCollection'].currentValue) {
       this.loadCheckpoints();
     }
+    if (changes['checkpointCordinatesCollection'] && changes['checkpointCordinatesCollection'].currentValue) {
+      this.setExecutionRoutes();
+    }
   }
+
+  private touristMarker: L.Marker | null = null; // Definišemo poseban marker za turistu
+
+
   private addTouristMarker(position: { latitude: number, longitude: number }): void {
-    // Clear existing tourist markers if any, then add a new one
-    const marker = L.marker([position.latitude, position.longitude]).addTo(this.map);
-    this.markers.push(marker);
-    marker.bindPopup('Current Tourist Position').openPopup();
+    // Ako marker već postoji, premesti ga na novu poziciju
+    if (this.touristMarker) {
+      this.touristMarker.setLatLng([position.latitude, position.longitude]);
+    } else {
+      // Ako marker ne postoji, kreiraj ga i dodaj na mapu
+      this.touristMarker = L.marker([position.latitude, position.longitude])
+        .addTo(this.map)
+        .bindPopup('Current Tourist Position')
+        .openPopup();
+      this.markers.push(this.touristMarker);
+    }
   }
 
   ngOnDestroy(): void {
@@ -207,6 +221,20 @@ export class MapComponent implements AfterViewInit,OnDestroy {
     }
   }
   
+  private setExecutionRoutes(): void {
+    if (this.checkpointCordinatesCollection && this.checkpointCordinatesCollection.length > 1) {
+      const waypoints = this.checkpointCordinatesCollection.map(coords => 
+        L.latLng(coords.latitude, coords.longitude)
+      );
+      
+      L.Routing.control({
+        waypoints: waypoints,
+        routeWhileDragging: true,
+        router: L.routing.mapbox('pk.eyJ1IjoicHN3Z3J1cGEyIiwiYSI6ImNtMmc5OWlybTAwNHEya3F4emZrMDVoZGsifQ.aD0uouzJcAGE--8As0GFjg', { profile: 'mapbox/driving' })
+      }).addTo(this.map);
+    }
+  }
+
   setRoute(): void {
     if (this.checkpointObjectCollection) {
       this.checkpointObjectCollection.forEach(tour => {


### PR DESCRIPTION
### Change Goal
As a tourist,
I want to start a tour and record my activities during tour,
So that I can track my progress and the time when I reached checkpoints.
Acceptance criteria:
The tourist's location is recorded using the Position simulator when the tour starts.
The tour session ends when the tourist:
completes the tour (status: completed), or
abandons the tour (status: abandoned).
Upon ending the session, the time of abandonment or completion is recorded.
The front-end sends a request every 10 seconds to check the tourist's current location.
If the tourist is near a key point, it is recorded in TourExecution that the tourist has completed that key point, along with the time of reaching it.
In any case (regardless of the outcome), the last activity (last activity DateTime) is recorded at the TourExecution object level.
### UI Changes
![image](https://github.com/user-attachments/assets/1dd005cf-89cd-4170-89af-317c6407457c)
